### PR TITLE
Csv helper fix

### DIFF
--- a/Controllers/CsvToJsonController.cs
+++ b/Controllers/CsvToJsonController.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using CsvHelper;
+using CsvHelper.Configuration;
 using System.IO;
 
 
@@ -32,12 +33,12 @@ namespace CsvToJsonCore.Controllers
 
             using (TextReader sr = new StringReader(body))
             {
-                var csv = new CsvReader(sr, System.Globalization.CultureInfo.CreateSpecificCulture("en-US"));
                 //set the delimiter type
-                csv.Configuration.Delimiter = delimiter.ToString();
+                var config = new CsvConfiguration(System.Globalization.CultureInfo.CurrentCulture) { Delimiter = delimiter.ToString() };
+                using var csv = new CsvReader(sr, config);
 
                 //read header - not necessary to leverage header record functionality currently
-                csv.Configuration.HasHeaderRecord = false;
+                //csv.Configuration.HasHeaderRecord = false;
                 if (csv.Read())
                 {
                     for (int i = 0; csv.TryGetField<string>(i, out value); i++)

--- a/CsvToJsonCore.csproj
+++ b/CsvToJsonCore.csproj
@@ -7,8 +7,6 @@
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="19.0.0" />
     <PackageReference Include="joelbyford.BasicAuth" Version="1.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.1" NoWarn="NU1605" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.1" NoWarn="NU1605" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.4" />
   </ItemGroup>
 

--- a/CsvToJsonCore.csproj
+++ b/CsvToJsonCore.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="19.0.0" />
+    <PackageReference Include="CsvHelper" Version="27.0.2" />
     <PackageReference Include="joelbyford.BasicAuth" Version="1.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.4" />
   </ItemGroup>


### PR DESCRIPTION
CSVHelper made a breaking change that needed to be fixed before the version could be bumped to latest.  This addresses that breaking change and also bumps to latest (per recommendation of Dependabot).