### PR TITLE
Adding Deploy to Azure Button Back

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 [![Test on Pull Request to Main](https://github.com/joelbyford/CSVtoJSONcore/actions/workflows/main-pr.yml/badge.svg)](https://github.com/joelbyford/CSVtoJSONcore/actions/workflows/main-pr.yml) [![Deploy on Push to Main](https://github.com/joelbyford/CSVtoJSONcore/actions/workflows/main-push.yml/badge.svg)](https://github.com/joelbyford/CSVtoJSONcore/actions/workflows/main-push.yml)
 
+**WARNING: GitHub Actions (build pipelines) will ONLY work if deploying to a paid App Service SKU that supports deployment slots.  If you choose a Free F1 SKU you will need to fork and change all GitHub Actions.**
+
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fjoelbyford%2FCSVtoJSONcore%2Frefs%2Fheads%2Fmain%2FDeployTemplates%2FAzureLinuxWebAppArm.json)
+
 
 
 # CSVtoJSONcore

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 [![Test on Pull Request to Main](https://github.com/joelbyford/CSVtoJSONcore/actions/workflows/main-pr.yml/badge.svg)](https://github.com/joelbyford/CSVtoJSONcore/actions/workflows/main-pr.yml) [![Deploy on Push to Main](https://github.com/joelbyford/CSVtoJSONcore/actions/workflows/main-push.yml/badge.svg)](https://github.com/joelbyford/CSVtoJSONcore/actions/workflows/main-push.yml)
 
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fjoelbyford%2FCSVtoJSONcore%2Frefs%2Fheads%2Fmain%2FDeployTemplates%2FAzureLinuxWebAppArm.json)
+
+
 # CSVtoJSONcore
 **IMPORTANT: For a .NET Framework version of this repo, please see [joelbyford/CSVtoJSON](https://github.com/joelbyford/CSVtoJSON) instead (which was forked from [jeffhollan/CSVtoJSON](https://github.com/jeffhollan/CSVtoJSON)).**
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Test on Pull Request to Main](https://github.com/joelbyford/CSVtoJSONcore/actions/workflows/main-pr.yml/badge.svg)](https://github.com/joelbyford/CSVtoJSONcore/actions/workflows/main-pr.yml) [![Deploy on Push to Main](https://github.com/joelbyford/CSVtoJSONcore/actions/workflows/main-push.yml/badge.svg)](https://github.com/joelbyford/CSVtoJSONcore/actions/workflows/main-push.yml)
 
-**WARNING: GitHub Actions (build pipelines) will ONLY work if deploying to a paid App Service SKU that supports deployment slots.  If you choose a Free F1 SKU you will need to fork and change all GitHub Actions.**
+**WARNING: GitHub Actions (build pipelines) will ONLY work if deploying to a paid App Service SKU that supports deployment slots.  If you choose a Free F1 SKU you will need to fork and change all GitHub Actions.  Please see the Deployment Instructions later in this Readme for how to create the required deployment slots.**
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fjoelbyford%2FCSVtoJSONcore%2Frefs%2Fheads%2Fmain%2FDeployTemplates%2FAzureLinuxWebAppArm.json)
 


### PR DESCRIPTION
Adding back WITH A WARNING that GitHub Actions require a paid subscription with deployment slots.  